### PR TITLE
Add npm script to run benchmarks

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "test": "test"
   },
   "scripts": {
-    "test": "gulp test"
+    "test": "gulp test",
+    "benchmark": "gulp benchmark"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
This allows folks to run `npm run benchmark` instead of running `gulp benchmark`

**Why?** `npm` looks at the installed deps to execute its scripts, so the user won't need to have installed `gulp` globally

**Ok, so?** It's also cool to hide developer tasks behind a single abstraction. If something new and shiny comes along, and `gulp` is swapped out, the developer task won't need to change. Also, having fewer prereqs to work with a repo is cool, I think.
