### PR TITLE
Update binarySearch.js

### DIFF
--- a/src/binarySearch.js
+++ b/src/binarySearch.js
@@ -10,21 +10,26 @@ function binarySearch(list, item) {
     var max = list.length - 1;
     var guess;
 
-    while (min <= max) {
-        guess = Math.floor((min + max) / 2);
-
-        if (list[guess] === item) {
-            return guess;
-        }
-        else {
-            if (list[guess] < item) {
-                min = guess + 1;
-            }
-            else {
-                max = guess - 1;
-            }
-        }
-    }
+	var bitwise = (max <= 2147483647) ? true : false;
+	if (bitwise) {
+		while (min <= max) {
+			guess = (min + max) >> 1;
+			if (list[guess] === item) { return guess; }
+			else {
+				if (list[guess] < item) { min = guess + 1; }
+				else { max = guess - 1; }
+			}
+		}
+	} else {
+		while (min <= max) {
+			guess = Math.floor((min + max) / 2);
+			if (list[guess] === item) { return guess; }
+			else {
+				if (list[guess] < item) { min = guess + 1; }
+				else { max = guess - 1; }
+			}
+		}
+	}
 
     return -1;
 }


### PR DESCRIPTION
Speed increase using bitwise shift for array length shorter than 32bit threshold (avoiding function overhead from Math.floor)
